### PR TITLE
allow anndata to write uppercase keys

### DIFF
--- a/examples/write_points.py
+++ b/examples/write_points.py
@@ -1,3 +1,4 @@
+from anndata._io.zarr import read_zarr
 import numpy as np
 import pandas as pd
 
@@ -31,3 +32,9 @@ write_points_dataset(
     points_dense_columns=['y', 'x'],
     points_var=var
 )
+
+# reload the points object
+anndata_obj = read_zarr('test_image/points')
+
+# confirm the data are the same
+np.testing.assert_almost_equal(points_coords, anndata_obj.X, decimal=5)

--- a/examples/write_points.py
+++ b/examples/write_points.py
@@ -37,4 +37,4 @@ write_points_dataset(
 anndata_obj = read_zarr('test_image/points')
 
 # confirm the data are the same
-np.testing.assert_almost_equal(points_coords, anndata_obj.X, decimal=5)
+np.testing.assert_almost_equal(points_coords, anndata_obj.X)

--- a/src/ngff_tables_prototype/table_utils.py
+++ b/src/ngff_tables_prototype/table_utils.py
@@ -33,7 +33,7 @@ def df_to_anndata(
     obs = df.drop(dense_columns, axis='columns')
 
     # create the AnnData object
-    ann_data_kwargs = {'X': dense_array, 'obs': obs}
+    ann_data_kwargs = {'X': dense_array, 'obs': obs, 'dtype': dense_array.dtype}
     if var is not None:
         ann_data_kwargs['var'] = var
     ann_obj = AnnData(**ann_data_kwargs)

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -19,6 +19,7 @@ def write_table(
 ):
     """code from: https://github.com/theislab/anndata/blob/0.7.8/anndata/_io/zarr.py
     """
+    group.store.normalize_keys = False
     if adata.raw is not None:
         adata.strings_to_categoricals(adata.raw.var)
     # TODO: Use spec writing system for this
@@ -37,6 +38,8 @@ def write_table(
     write_attribute(group, "layers", adata.layers, dataset_kwargs)
     write_attribute(group, "uns", adata.uns, dataset_kwargs)
     write_attribute(group, "raw", adata.raw, dataset_kwargs)
+
+    group.store.normalize_keys = True
 
 
 def write_points_dataset(

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -11,6 +11,7 @@ import zarr
 
 from .table_utils import df_to_anndata
 
+
 def write_table(
         group: zarr.Group,
         adata: AnnData,
@@ -19,7 +20,10 @@ def write_table(
 ):
     """code from: https://github.com/theislab/anndata/blob/0.7.8/anndata/_io/zarr.py
     """
+    # AnnData requires an upper case key for X
+    # todo: make context manager?
     group.store.normalize_keys = False
+
     if adata.raw is not None:
         adata.strings_to_categoricals(adata.raw.var)
     # TODO: Use spec writing system for this
@@ -39,6 +43,7 @@ def write_table(
     write_attribute(group, "uns", adata.uns, dataset_kwargs)
     write_attribute(group, "raw", adata.raw, dataset_kwargs)
 
+    # revert the store to normalizing keys
     group.store.normalize_keys = True
 
 


### PR DESCRIPTION
@jhnnsrs discovered that we were forcing the table keys to be lower case. This is incompatible with AnnData, which expects the dense matrix key to be `X` (i.e., upper case). This PR provides a fix by allowing the keys to be upper case when writting the AnnData group.