### PR TITLE
Add matplotlib dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     napari-ome-zarr
     ome-zarr
     pandas
+    matplotlib
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     ome-zarr
     pandas
     matplotlib
+    squidpy
 
 
 [options.packages.find]


### PR DESCRIPTION
Hey @kevinyamauchi 

I was trying to run your `examples/save_load_points.py` example, but ran into a missing matplotlib dependency. This should fix that dependency :)