### PR TITLE
[WIP] High Content Screening OME-NGFF example

### DIFF
--- a/examples/save_load_hcs_data.py
+++ b/examples/save_load_hcs_data.py
@@ -1,0 +1,54 @@
+import napari
+import os
+import shutil
+import squidpy as sq
+from ngff_tables_prototype.writer import write_spatial_anndata
+from ngff_tables_prototype.reader import load_to_napari_viewer
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import anndata as ad
+
+# Instructions
+# Download files from here:
+# https://drive.google.com/drive/folders/1TWMcKSQuq_ZEkTPPCLOO4sE6oMlhSGu_?usp=sharing
+# Place it in the ome-ngff-tables-prototype folder and run the script from
+# the example folder
+# Unzip the OME-Zarr file
+output_fpath = Path("../HCS_Example_Data/UZH_2x2_HCS.ome.zarr")
+feature_path = Path("../HCS_Example_Data/FeatureData")
+
+def write_hcs_table() -> None:
+    # Loop over the 4 sites
+    # Check that data was downloaded
+    assert len(os.listdir(feature_path)) == 4, 'Feature data should contain \
+                                            for files. Check instructions above'
+    assert os.path.isdir(output_fpath), 'OME Zarr folder does not exist. Was it unzipped?'
+
+    # TODO: Check if feature data has already been written to the OME-Zarr file
+
+    # Loop through all 4 fields of view,
+    # load the feature data & save to OME-Zarr file
+    for site in range(4):
+        df = pd.read_csv(feature_path / f'HCS_FeatureData_Site{site}.csv')
+        df_x = df.iloc[:, :-2]
+        features_ad = ad.AnnData(df_x.loc[:, df_x.columns != 'Label'])
+        features_ad.obs = pd.concat([df['Label'], df.iloc[:, -2:]], axis = 1)
+        write_spatial_anndata(
+            file_path=output_fpath / 'B' / '03' / str(site),
+            tables_adata=features_ad,
+            tables_region="labels/label_image",
+            tables_instance_key="Label",
+        )
+
+    return
+
+
+if __name__ == "__main__":
+    write_hcs_table()
+    print(output_fpath)
+    viewer = load_to_napari_viewer(
+        file_path=output_fpath / 'B' / '03' / '0',
+        groups=["labels/label_image", "tables/regions_table"],
+    )
+    napari.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     napari-ome-zarr
     ome-zarr
     pandas
+    matplotlib
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     ome-zarr
     pandas
     matplotlib
+    squidpy
 
 
 [options.packages.find]

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -127,6 +127,7 @@ def write_spatial_anndata(
     # label group
     label_image: Optional[np.ndarray] = None,
     label_name: str = "label_image",
+    label_axes: list = ['y', 'x'],
     # table group
     tables_adata: Optional[AnnData] = None,
     tables_region: Optional[Union[str, List[str]]] = None,
@@ -158,6 +159,8 @@ def write_spatial_anndata(
         The name of the label image. See ome-zarr-py for details.
     label_image : Union[str, List[str]]
         The label image (i.e. segmentation mask). See ome-zarr-py for details.
+    label_axes: list
+        The labels for the label image axes. See ome-zarr-py for details. Defaults to ['y', 'x'] for 2D images
     tables_adata:
         The :class:`anndata.AnnData` table with gene expression and annotations.
     tables_region
@@ -241,7 +244,7 @@ def write_spatial_anndata(
     if label_image is not None:
         # i.e. segmentation raster masks
         # the function write labels will create the group labels, so we pass the root
-        write_labels(label_image, group=root, name=label_name)
+        write_labels(label_image, group=root, name=label_name, axes=label_axes)
 
     if tables_adata is not None:
         # e.g. expression table


### PR DESCRIPTION
I'm trying to add an HCS example dataset, here's a WIP PR for this.

Motivation: Provide example data in the OME-NGFF High Content Screening format spec

My example dataset contains 2x2 field of views (fovs) for a single well, with label images, already saved in the OME-Zarr HCS spec. Additionally, I have feature measurements for each site saved as csvs and an example script that loads those measurements and saves them as an AnnData table per site. The saving seems to work nicely and I have an AnnData tables folder per fov. Really cool to see this working already!


**Current issues:**
1. I don't have a nice way to share example data. It's currently on a Google Drive, but my attempts to use gdown to download it from there directly have failed. Does anyone know an easy way to fix this? At the moment, one needs to follow the instructions in the example file to manually download the data first, unzip the OME-Zarr file & then run the example.
2. It seems the `load_to_napari_viewer` function is [flipping x & y dimensions here](https://github.com/kevinyamauchi/ome-ngff-tables-prototype/blob/c7aa680234cd13897d526796485ca9095afa52d1/src/ngff_tables_prototype/reader.py#L55). Is that intentional? When I open my images with the napari-ome-zarr plugin, they are displayed like this:
<img width="1531" alt="Screenshot 2022-06-23 at 18 46 10" src="https://user-images.githubusercontent.com/18033446/175354015-da55a3a7-7a86-4196-9d08-c8971b1c8764.png">
But when I open them with `load_to_napari_viewer`, x&y dimensions are flipped for the images (but not for the label, thus making the label not match the images anymore)
<img width="1531" alt="Screenshot 2022-06-23 at 18 46 13" src="https://user-images.githubusercontent.com/18033446/175354178-95b38daa-c8b6-4af8-999a-471f1b40a899.png">

3. It appears the loading isn't designed to handle the plate spec. I haven't had time to look into it much. At the moment, I just load the first field of view, because `load_to_napari_viewer` throws a `zarr.errors.ContainsGroupError: path 'tables' contains a group` if I provide e.g. the full well (and full plates currently don't support displaying label images in ome-zarr-py, see here: https://github.com/ome/ome-zarr-py/issues/65#issuecomment-1155295470

**Solved Issues:**
1. I also used the library originally to save my label images to the OME-Zarr file. Saving 3D label images needed axes parameters & I added parsing for those for label images (not used in the example anymore, but maybe useful to somebody else)
