### PR TITLE
consolidate_metadata for tables

### DIFF
--- a/examples/fix_dtype.py
+++ b/examples/fix_dtype.py
@@ -1,0 +1,47 @@
+
+import sys
+import zarr
+import numpy as np
+import argparse
+
+# convert zarr dypes from int64 (i8) to int32 (i4) to allow data
+# to be loaded via JavaScript using zarr.js
+
+def main(argv):
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path', help='Path to e.g. "test_segment.zarr/tables/regions_table/obs"')
+    args = parser.parse_args(argv)
+    zarr_path = args.path
+
+
+    name_list = []
+    data_list = []
+    chunk_list = []
+    # store = zarr.DirectoryStore(zarr_path, dimension_separator="/")
+    with zarr.open(zarr_path, "a") as f:
+        col_names = []
+        f.visit(lambda x: col_names.append(x))
+        print('col_names', col_names)
+        for ds_name in col_names:
+            data = f[ds_name]
+            # if we have an int64 array...
+            if hasattr(data, "dtype") and data.dtype == np.int64:
+                print("fix dtype...", ds_name)
+                data = f[ds_name][:].astype("int32")
+                chunks = f[ds_name].chunks
+                # delete and replace...
+                del f[ds_name]
+                name_list.append(ds_name)
+                data_list.append(data)
+                chunk_list.append(chunks)
+        
+        for ii, ds_name in enumerate(name_list):
+            print("write ii, ds_name", ii, ds_name)
+            data = data_list[ii]
+            chunks = chunk_list[ii]
+            f.create_dataset(ds_name, data=data, chunks=chunks)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -54,7 +54,10 @@ def write_table_regions(
     instance_key: Optional[str] = None,
 ):
     write_elem(group, table_group_name, adata)
-    group.attrs["tables"] = [table_group_name]
+    # add table_group_name to "tables" list
+    table_attrs = group.attrs.asdict().get("tables", [])
+    table_attrs.append(table_group_name)
+    group.attrs["tables"] = table_attrs
     table_group = group[table_group_name]
     table_group.attrs["type"] = group_type
     table_group.attrs["region"] = region

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, Tuple, Any, List
 
+import os
 import anndata
 from anndata import AnnData
 import numpy as np
@@ -245,7 +246,8 @@ def write_spatial_anndata(
 
     if tables_adata is not None:
         # e.g. expression table
-        tables_group = root.create_group(name="tables")
+        TABLES_GROUP_NAME = "tables"
+        tables_group = root.create_group(name=TABLES_GROUP_NAME)
         write_table_regions(
             group=tables_group,
             adata=tables_adata,
@@ -253,6 +255,9 @@ def write_spatial_anndata(
             region_key=tables_region_key,
             instance_key=tables_instance_key,
         )
+        # consolidate metadata...
+        store = zarr.DirectoryStore(os.path.join(file_path, TABLES_GROUP_NAME))
+        zarr.consolidate_metadata(store)
     if circles_adata is not None:
         # was it called circles? I didn't take a pic of the whiteboard
         circles_group = root.create_group(name="circles")

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -61,6 +61,16 @@ def write_table_regions(
     table_group.attrs["region_key"] = region_key
     table_group.attrs["instance_key"] = instance_key
 
+    # Simple, local "consolidate_metadata" to list child groups
+    def index_group(grp_name):
+        if grp_name in ["layers", "obsm", "obsp", "raw", "uns"]:
+            keys = []
+            sub_group = table_group[grp_name]
+            sub_group.visit(lambda x: keys.append(x))
+            sub_group.attrs["keys"] = keys
+
+    table_group.visit(index_group)
+
 
 def write_points_dataset(
     file_path: str,

--- a/src/ngff_tables_prototype/writer.py
+++ b/src/ngff_tables_prototype/writer.py
@@ -1,6 +1,5 @@
 from typing import Optional, Union, Tuple, Any, List
 
-import os
 import anndata
 from anndata import AnnData
 import numpy as np
@@ -55,6 +54,7 @@ def write_table_regions(
     instance_key: Optional[str] = None,
 ):
     write_elem(group, table_group_name, adata)
+    group.attrs["tables"] = [table_group_name]
     table_group = group[table_group_name]
     table_group.attrs["type"] = group_type
     table_group.attrs["region"] = region
@@ -246,8 +246,7 @@ def write_spatial_anndata(
 
     if tables_adata is not None:
         # e.g. expression table
-        TABLES_GROUP_NAME = "tables"
-        tables_group = root.create_group(name=TABLES_GROUP_NAME)
+        tables_group = root.create_group(name="tables")
         write_table_regions(
             group=tables_group,
             adata=tables_adata,
@@ -255,9 +254,6 @@ def write_spatial_anndata(
             region_key=tables_region_key,
             instance_key=tables_instance_key,
         )
-        # consolidate metadata...
-        store = zarr.DirectoryStore(os.path.join(file_path, TABLES_GROUP_NAME))
-        zarr.consolidate_metadata(store)
     if circles_adata is not None:
         # was it called circles? I didn't take a pic of the whiteboard
         circles_group = root.create_group(name="circles")


### PR DESCRIPTION
See discussion at https://github.com/ome/ngff/pull/64/files#r1025073730

In order to allow full access to all the `tables` metadata when the ability to `ls` subdirectories is not available (e.g. over https / s3), `consolidate_metadata()` can be used to add metadata to the `image.zarr/tables` group.

This would also provide a work-around for the listing of tables within that top-level `tables` group. See https://github.com/ome/ngff/pull/64/files#r1022858025

cc @ivirshup @joshmoore